### PR TITLE
Clean up incomplete Moonshine model downloads

### DIFF
--- a/app/src/main/java/com/hush/app/transcription/ModelManager.kt
+++ b/app/src/main/java/com/hush/app/transcription/ModelManager.kt
@@ -138,7 +138,10 @@ class ModelManager(private val context: Context) {
         val allowedNames = AVAILABLE_MODELS.flatMap { listOf(it.fileName, "${it.fileName}.tmp") }.toSet()
 
         modelsDir.listFiles()?.forEach { file ->
-            if (file.isDirectory) return@forEach // skip moonshine subdirectory
+            if (file.isDirectory) {
+                if (file.name == MOONSHINE_DIR) cleanOrphanedMoonshineModels(file)
+                return@forEach
+            }
             if (file.name in allowedNames) return@forEach
             if (file.name.endsWith(".pte") || file.name.endsWith(".tmp")) {
                 val sizeMb = file.length() / (1024 * 1024)
@@ -146,6 +149,37 @@ class ModelManager(private val context: Context) {
                 file.delete()
             } else {
                 Log.i(TAG, "Skipping unexpected file in models dir: ${file.name}")
+            }
+        }
+    }
+
+    private fun cleanOrphanedMoonshineModels(moonshineDir: File) {
+        val knownIds = AVAILABLE_MOONSHINE_MODELS.associateBy { it.dirName }
+
+        moonshineDir.listFiles()?.forEach { dir ->
+            if (!dir.isDirectory) {
+                dir.delete()
+                return@forEach
+            }
+
+            val info = knownIds[dir.name]
+            if (info == null) {
+                Log.i(TAG, "Deleting orphaned moonshine model dir: ${dir.name}")
+                dir.deleteRecursively()
+                return@forEach
+            }
+
+            // Clean .tmp files from interrupted downloads
+            dir.listFiles()?.filter { it.name.endsWith(".tmp") }?.forEach { tmp ->
+                Log.i(TAG, "Deleting orphaned moonshine tmp: ${dir.name}/${tmp.name}")
+                tmp.delete()
+            }
+
+            // Delete entire dir if not all components are present
+            val allPresent = info.components.all { File(dir, it).exists() }
+            if (!allPresent) {
+                Log.i(TAG, "Deleting incomplete moonshine model: ${dir.name}")
+                dir.deleteRecursively()
             }
         }
     }

--- a/app/src/test/java/com/hush/app/ModelManagerTest.kt
+++ b/app/src/test/java/com/hush/app/ModelManagerTest.kt
@@ -277,6 +277,81 @@ class ModelManagerTest {
         assertTrue(statuses.containsKey("tiny-streaming-en"))
     }
 
+    // --- Moonshine cleanup tests ---
+
+    @Test
+    fun `cleanOrphanedModels deletes incomplete moonshine model dir`() {
+        val info = ModelManager.getMoonshineModelInfo("tiny-streaming-en")!!
+        val dir = File(manager.getModelsDir(), "moonshine/${info.dirName}")
+        dir.mkdirs()
+        // Create only 3 of 7 components
+        info.components.take(3).forEach { File(dir, it).writeText("data") }
+
+        manager.cleanOrphanedModels()
+
+        assertFalse(dir.exists())
+    }
+
+    @Test
+    fun `cleanOrphanedModels keeps complete moonshine model dir`() {
+        val info = ModelManager.getMoonshineModelInfo("tiny-streaming-en")!!
+        val dir = File(manager.getModelsDir(), "moonshine/${info.dirName}")
+        dir.mkdirs()
+        info.components.forEach { File(dir, it).writeText("data") }
+
+        manager.cleanOrphanedModels()
+
+        assertTrue(dir.exists())
+        info.components.forEach { assertTrue(File(dir, it).exists()) }
+
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `cleanOrphanedModels deletes orphaned moonshine model dir`() {
+        val moonshineDir = File(manager.getModelsDir(), "moonshine")
+        val orphanedDir = File(moonshineDir, "unknown-model-xyz")
+        orphanedDir.mkdirs()
+        File(orphanedDir, "some_file.ort").writeText("data")
+
+        manager.cleanOrphanedModels()
+
+        assertFalse(orphanedDir.exists())
+    }
+
+    @Test
+    fun `cleanOrphanedModels deletes tmp files inside moonshine model dir`() {
+        val info = ModelManager.getMoonshineModelInfo("tiny-streaming-en")!!
+        val dir = File(manager.getModelsDir(), "moonshine/${info.dirName}")
+        dir.mkdirs()
+        // Create all real components + some .tmp files
+        info.components.forEach { File(dir, it).writeText("data") }
+        File(dir, "encoder.ort.tmp").writeText("partial")
+        File(dir, "decoder_kv.ort.tmp").writeText("partial")
+
+        manager.cleanOrphanedModels()
+
+        // Real files kept, tmp files removed
+        assertTrue(dir.exists())
+        info.components.forEach { assertTrue(File(dir, it).exists()) }
+        assertFalse(File(dir, "encoder.ort.tmp").exists())
+        assertFalse(File(dir, "decoder_kv.ort.tmp").exists())
+
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `cleanOrphanedModels deletes stray files in moonshine dir`() {
+        val moonshineDir = File(manager.getModelsDir(), "moonshine")
+        moonshineDir.mkdirs()
+        val strayFile = File(moonshineDir, "leftover.tmp")
+        strayFile.writeText("stray data")
+
+        manager.cleanOrphanedModels()
+
+        assertFalse(strayFile.exists())
+    }
+
     @Test
     fun `refreshStatuses updates status to READY when file exists`() {
         val modelsDir = manager.getModelsDir()


### PR DESCRIPTION
## Summary
- `cleanOrphanedModels()` now handles the `moonshine/` subdirectory instead of skipping all directories
- New `cleanOrphanedMoonshineModels()` cleans up `.tmp` files from interrupted downloads, deletes incomplete model dirs (missing components), and removes unknown/orphaned model dirs
- 5 new unit tests covering all cleanup scenarios

## Test plan
- [x] Unit tests pass (`ModelManagerTest` — 5 new tests, all green)
- [x] Full test suite passes (no regressions)
- [x] Emulator smoke test — app launches, no crashes, logcat clean
- [x] Pixel update install — app runs normally, Moonshine download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)