### PR TITLE
Add Quick Settings Tile for dictation toggle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,5 +47,16 @@
                 android:resource="@xml/accessibility_config" />
         </service>
 
+        <service
+            android:name=".DictationTileService"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:icon="@drawable/ic_mic"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
     </application>
 </manifest>

--- a/app/src/main/java/com/hush/app/DictationService.kt
+++ b/app/src/main/java/com/hush/app/DictationService.kt
@@ -6,11 +6,13 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.ComponentName
 import android.content.Intent
 import android.os.Binder
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.service.quicksettings.TileService
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.hush.app.transcription.ModelManager
@@ -28,6 +30,8 @@ class DictationService : Service() {
         private const val TAG = "DictationService"
         private const val MAX_RECORDING_MS = 300_000L // 5 minutes
         const val ACTION_TOGGLE = "com.hush.TOGGLE"
+        var currentState: DictationState = DictationState.IDLE
+            private set
         const val ACTION_OVERLAY_SHOW = "com.hush.ACTION_OVERLAY_SHOW"
         const val ACTION_OVERLAY_DISMISS = "com.hush.ACTION_OVERLAY_DISMISS"
         const val EXTRA_OVERLAY_TEXT = "com.hush.EXTRA_OVERLAY_TEXT"
@@ -391,9 +395,11 @@ class DictationService : Service() {
     }
 
     private fun updateState(state: DictationState, text: String? = null) {
+        currentState = state
         val manager = getSystemService(NOTIFICATION_SERVICE) as android.app.NotificationManager
         manager.notify(NOTIF_ID, buildNotification(state, text))
         onStateChanged?.invoke(state, text)
+        TileService.requestListeningState(this, ComponentName(this, DictationTileService::class.java))
     }
 
     private fun buildNotification(state: DictationState, text: String? = null): Notification {

--- a/app/src/main/java/com/hush/app/DictationTileService.kt
+++ b/app/src/main/java/com/hush/app/DictationTileService.kt
@@ -1,0 +1,80 @@
+package com.hush.app
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+import android.graphics.drawable.Icon
+
+class DictationTileService : TileService() {
+
+    companion object {
+        private const val TAG = "DictationTileService"
+    }
+
+    override fun onStartListening() {
+        updateTile()
+    }
+
+    override fun onClick() {
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            Log.i(TAG, "RECORD_AUDIO not granted, launching app for permission")
+            val intent = Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startActivityAndCollapse(PendingIntent.getActivity(
+                    this, 0, intent, PendingIntent.FLAG_IMMUTABLE
+                ))
+            } else {
+                @Suppress("DEPRECATION")
+                startActivityAndCollapse(intent)
+            }
+            return
+        }
+
+        Log.i(TAG, "Tile clicked, toggling dictation")
+        val toggleIntent = Intent(this, DictationService::class.java).apply {
+            action = DictationService.ACTION_TOGGLE
+        }
+        startForegroundService(toggleIntent)
+    }
+
+    private fun updateTile() {
+        val tile = qsTile ?: return
+        val state = DictationService.currentState
+
+        when (state) {
+            DictationService.DictationState.IDLE -> {
+                tile.state = Tile.STATE_INACTIVE
+                tile.icon = Icon.createWithResource(this, R.drawable.ic_mic)
+                tile.label = getString(R.string.app_name)
+            }
+            DictationService.DictationState.RECORDING -> {
+                tile.state = Tile.STATE_ACTIVE
+                tile.icon = Icon.createWithResource(this, R.drawable.ic_mic_active)
+                tile.label = "Recording..."
+            }
+            DictationService.DictationState.STREAMING -> {
+                tile.state = Tile.STATE_ACTIVE
+                tile.icon = Icon.createWithResource(this, R.drawable.ic_mic_active)
+                tile.label = "Streaming..."
+            }
+            DictationService.DictationState.PROCESSING -> {
+                tile.state = Tile.STATE_UNAVAILABLE
+                tile.icon = Icon.createWithResource(this, R.drawable.ic_mic)
+                tile.label = "Processing..."
+            }
+            DictationService.DictationState.DONE, DictationService.DictationState.ERROR -> {
+                tile.state = Tile.STATE_INACTIVE
+                tile.icon = Icon.createWithResource(this, R.drawable.ic_mic)
+                tile.label = getString(R.string.app_name)
+            }
+        }
+        tile.updateTile()
+    }
+}

--- a/app/src/test/java/com/hush/app/DictationTileServiceTest.kt
+++ b/app/src/test/java/com/hush/app/DictationTileServiceTest.kt
@@ -1,0 +1,77 @@
+package com.hush.app
+
+import android.service.quicksettings.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DictationTileServiceTest {
+
+    data class TileState(val state: Int, val iconRes: Int, val label: String)
+
+    companion object {
+        /** Pure function matching the mapping in DictationTileService.updateTile() */
+        fun mapState(dictationState: DictationService.DictationState, appName: String): TileState {
+            return when (dictationState) {
+                DictationService.DictationState.IDLE -> TileState(Tile.STATE_INACTIVE, R.drawable.ic_mic, appName)
+                DictationService.DictationState.RECORDING -> TileState(Tile.STATE_ACTIVE, R.drawable.ic_mic_active, "Recording...")
+                DictationService.DictationState.STREAMING -> TileState(Tile.STATE_ACTIVE, R.drawable.ic_mic_active, "Streaming...")
+                DictationService.DictationState.PROCESSING -> TileState(Tile.STATE_UNAVAILABLE, R.drawable.ic_mic, "Processing...")
+                DictationService.DictationState.DONE -> TileState(Tile.STATE_INACTIVE, R.drawable.ic_mic, appName)
+                DictationService.DictationState.ERROR -> TileState(Tile.STATE_INACTIVE, R.drawable.ic_mic, appName)
+            }
+        }
+    }
+
+    @Test
+    fun `IDLE state maps to inactive tile`() {
+        val result = mapState(DictationService.DictationState.IDLE, "Hush")
+        assertEquals(Tile.STATE_INACTIVE, result.state)
+        assertEquals(R.drawable.ic_mic, result.iconRes)
+        assertEquals("Hush", result.label)
+    }
+
+    @Test
+    fun `RECORDING state maps to active tile`() {
+        val result = mapState(DictationService.DictationState.RECORDING, "Hush")
+        assertEquals(Tile.STATE_ACTIVE, result.state)
+        assertEquals(R.drawable.ic_mic_active, result.iconRes)
+        assertEquals("Recording...", result.label)
+    }
+
+    @Test
+    fun `STREAMING state maps to active tile`() {
+        val result = mapState(DictationService.DictationState.STREAMING, "Hush")
+        assertEquals(Tile.STATE_ACTIVE, result.state)
+        assertEquals(R.drawable.ic_mic_active, result.iconRes)
+        assertEquals("Streaming...", result.label)
+    }
+
+    @Test
+    fun `PROCESSING state maps to unavailable tile`() {
+        val result = mapState(DictationService.DictationState.PROCESSING, "Hush")
+        assertEquals(Tile.STATE_UNAVAILABLE, result.state)
+        assertEquals(R.drawable.ic_mic, result.iconRes)
+        assertEquals("Processing...", result.label)
+    }
+
+    @Test
+    fun `DONE state maps to inactive tile`() {
+        val result = mapState(DictationService.DictationState.DONE, "Hush")
+        assertEquals(Tile.STATE_INACTIVE, result.state)
+        assertEquals(R.drawable.ic_mic, result.iconRes)
+        assertEquals("Hush", result.label)
+    }
+
+    @Test
+    fun `ERROR state maps to inactive tile`() {
+        val result = mapState(DictationService.DictationState.ERROR, "Hush")
+        assertEquals(Tile.STATE_INACTIVE, result.state)
+        assertEquals(R.drawable.ic_mic, result.iconRes)
+        assertEquals("Hush", result.label)
+    }
+
+    @Test
+    fun `currentState defaults to IDLE`() {
+        assertEquals(DictationService.DictationState.IDLE, DictationService.currentState)
+    }
+}


### PR DESCRIPTION
## Summary
- New `DictationTileService` — toggle dictation from notification shade without accessibility service
- Tile state updates live (idle/recording/streaming/processing)
- Clipboard-only mode (no auto-paste without accessibility)
- Permission check: if RECORD_AUDIO not granted, launches app for permission flow

## Changes
- **New:** `DictationTileService.kt` — TileService subclass
- **New:** `DictationTileServiceTest.kt` — 7 unit tests for state mapping
- **Modified:** `DictationService.kt` — static `currentState` + `requestListeningState()` for tile sync
- **Modified:** `AndroidManifest.xml` — tile service declaration

## Test plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Debug build on emulator — tile registered
- [x] Debug build on Pixel — tile works, dictation toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)