### PR TITLE
Add StatusPill overlay for external dictation feedback

### DIFF
--- a/app/src/main/java/com/hush/app/DictationService.kt
+++ b/app/src/main/java/com/hush/app/DictationService.kt
@@ -37,6 +37,10 @@ class DictationService : Service() {
         const val EXTRA_OVERLAY_TEXT = "com.hush.EXTRA_OVERLAY_TEXT"
         const val EXTRA_OVERLAY_MODEL = "com.hush.EXTRA_OVERLAY_MODEL"
         const val NOTIF_ID = 1
+        const val ACTION_STATUS_PILL = "com.hush.ACTION_STATUS_PILL"
+        const val EXTRA_PILL_TYPE = "com.hush.EXTRA_PILL_TYPE"
+        const val EXTRA_PILL_MESSAGE = "com.hush.EXTRA_PILL_MESSAGE"
+        const val EXTRA_WORD_COUNT = "com.hush.EXTRA_WORD_COUNT"
     }
 
     inner class LocalBinder : Binder() {
@@ -107,6 +111,8 @@ class DictationService : Service() {
             isRecording = true
             recordingStartMs = System.currentTimeMillis()
             updateState(DictationState.RECORDING)
+            val config = ProviderRepository.getConfig(this, ProviderRepository.getActiveProviderId(this))
+            sendStatusPill("START", "Hush \u00b7 ${config.displayLabel} \u00b7 ${versionLabel()}")
             autoStopJob = scope.launch {
                 delay(MAX_RECORDING_MS)
                 if (isRecording) {
@@ -115,6 +121,7 @@ class DictationService : Service() {
             }
         } else {
             updateState(DictationState.ERROR, "Microphone unavailable — check permissions")
+            sendStatusPill("ERROR", "Microphone unavailable")
         }
     }
 
@@ -127,6 +134,7 @@ class DictationService : Service() {
 
         val file = audioRecorder?.stop() ?: run {
             updateState(DictationState.ERROR, "Recorder failed to save audio")
+            sendStatusPill("ERROR", "Recorder failed to save audio")
             return
         }
 
@@ -143,13 +151,18 @@ class DictationService : Service() {
                                 val wordCount = result.text.trim().split("\\s+".toRegex()).size
                                 UsageRepository.recordSession(this@DictationService, recordingStartMs, durationSeconds, wordCount)
                                 HistoryRepository.addEntry(this@DictationService, result.text)
+                                copyToClipboard(result.text)
+                                sendBroadcast(Intent(HushAccessibilityService.ACTION_INJECT_TEXT).setPackage(packageName).apply {
+                                    putExtra(EXTRA_WORD_COUNT, wordCount)
+                                })
+                            } else {
+                                sendStatusPill("DONE", "Done \u00b7 no speech detected")
                             }
-                            copyToClipboard(result.text)
-                            sendBroadcast(Intent(HushAccessibilityService.ACTION_INJECT_TEXT).setPackage(packageName))
                             updateState(DictationState.DONE, result.text)
                         }
                         is TranscribeResult.Error -> {
                             updateState(DictationState.ERROR, result.message)
+                            sendStatusPill("ERROR", result.message)
                         }
                     }
                 }
@@ -157,6 +170,7 @@ class DictationService : Service() {
                 Log.e(TAG, "Error during transcription", e)
                 withContext(Dispatchers.Main) {
                     updateState(DictationState.ERROR, "Unexpected error: ${e.message}")
+                    sendStatusPill("ERROR", "Unexpected error: ${e.message}")
                 }
             } finally {
                 file.delete()
@@ -183,6 +197,7 @@ class DictationService : Service() {
         val modelPath = modelManager.getMoonshineModelPath(config.model)
         if (modelPath == null) {
             updateState(DictationState.ERROR, "Moonshine model not downloaded — go to Settings")
+            sendStatusPill("ERROR", "Model not downloaded")
             return
         }
 
@@ -196,6 +211,7 @@ class DictationService : Service() {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize Moonshine", e)
             updateState(DictationState.ERROR, "Failed to load model: ${e.message}")
+            sendStatusPill("ERROR", "Failed to load model")
             return
         }
 
@@ -248,6 +264,7 @@ class DictationService : Service() {
                     moonshineProvider = null
                 }
                 updateState(DictationState.ERROR, message)
+                sendStatusPill("ERROR", message)
             }
         }
 
@@ -256,6 +273,7 @@ class DictationService : Service() {
         recordingStartMs = System.currentTimeMillis()
         provider.start()
         updateState(DictationState.STREAMING)
+        sendStatusPill("START", "Hush \u00b7 ${config.displayLabel} \u00b7 ${versionLabel()}")
 
         autoStopJob = scope.launch {
             delay(MAX_RECORDING_MS)
@@ -325,6 +343,7 @@ class DictationService : Service() {
                     voxtralRealtimeProvider = null
                 }
                 updateState(DictationState.ERROR, message)
+                sendStatusPill("ERROR", message)
             }
         }
 
@@ -333,6 +352,7 @@ class DictationService : Service() {
         recordingStartMs = System.currentTimeMillis()
         provider.start()
         updateState(DictationState.STREAMING)
+        sendStatusPill("START", "Hush \u00b7 ${config.displayLabel} \u00b7 ${versionLabel()}")
 
         autoStopJob = scope.launch {
             delay(MAX_RECORDING_MS)
@@ -378,9 +398,14 @@ class DictationService : Service() {
         if (streamingToExternalApp) {
             sendBroadcast(Intent(ACTION_OVERLAY_DISMISS).setPackage(packageName))
             if (finalText.isNotBlank()) {
+                val wordCount = finalText.split("\\s+".toRegex()).size
                 mainHandler.postDelayed({
-                    sendBroadcast(Intent(HushAccessibilityService.ACTION_INJECT_TEXT).setPackage(packageName))
+                    sendBroadcast(Intent(HushAccessibilityService.ACTION_INJECT_TEXT).setPackage(packageName).apply {
+                        putExtra(EXTRA_WORD_COUNT, wordCount)
+                    })
                 }, 150)
+            } else {
+                sendStatusPill("DONE", "Done \u00b7 no speech detected")
             }
         }
 
@@ -388,6 +413,19 @@ class DictationService : Service() {
     }
 
     // --- Common ---
+
+    private fun sendStatusPill(type: String, message: String) {
+        if (isAppInForeground) return
+        sendBroadcast(Intent(ACTION_STATUS_PILL).setPackage(packageName).apply {
+            putExtra(EXTRA_PILL_TYPE, type)
+            putExtra(EXTRA_PILL_MESSAGE, message)
+        })
+    }
+
+    private fun versionLabel(): String {
+        val v = BuildConfig.VERSION_NAME
+        return if (BuildConfig.DEBUG) "${v}-dev" else v
+    }
 
     private fun copyToClipboard(text: String) {
         val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager

--- a/app/src/main/java/com/hush/app/HushAccessibilityService.kt
+++ b/app/src/main/java/com/hush/app/HushAccessibilityService.kt
@@ -20,6 +20,7 @@ class HushAccessibilityService : AccessibilityService() {
 
     private var lastVolumeDownTime = 0L
     private lateinit var overlayManager: StreamingOverlayManager
+    private lateinit var statusPillOverlay: StatusPillOverlay
 
     private val overlayReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -38,19 +39,31 @@ class HushAccessibilityService : AccessibilityService() {
 
     private val injectReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
+            val wordCount = intent?.getIntExtra(DictationService.EXTRA_WORD_COUNT, 0) ?: 0
             val focused = rootInActiveWindow?.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
             if (focused == null) {
                 Log.i(TAG, "No focused text field — text remains on clipboard")
+                statusPillOverlay.show(StatusPillOverlay.PillType.DONE, "Copied \u00b7 no text field")
                 return
             }
             focused.performAction(AccessibilityNodeInfo.ACTION_PASTE)
             Log.i(TAG, "Pasted transcription")
+            statusPillOverlay.show(StatusPillOverlay.PillType.DONE, "Pasted \u00b7 $wordCount words")
+        }
+    }
+
+    private val pillReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val type = intent?.getStringExtra(DictationService.EXTRA_PILL_TYPE) ?: return
+            val message = intent.getStringExtra(DictationService.EXTRA_PILL_MESSAGE) ?: return
+            statusPillOverlay.show(type, message)
         }
     }
 
     override fun onServiceConnected() {
         super.onServiceConnected()
         overlayManager = StreamingOverlayManager(this)
+        statusPillOverlay = StatusPillOverlay(this)
 
         val overlayFilter = IntentFilter().apply {
             addAction(DictationService.ACTION_OVERLAY_SHOW)
@@ -58,7 +71,8 @@ class HushAccessibilityService : AccessibilityService() {
         }
         registerReceiver(overlayReceiver, overlayFilter, Context.RECEIVER_NOT_EXPORTED)
         registerReceiver(injectReceiver, IntentFilter(ACTION_INJECT_TEXT), Context.RECEIVER_NOT_EXPORTED)
-        Log.i(TAG, "Registered overlay and inject broadcast receivers")
+        registerReceiver(pillReceiver, IntentFilter(DictationService.ACTION_STATUS_PILL), Context.RECEIVER_NOT_EXPORTED)
+        Log.i(TAG, "Registered overlay, inject, and pill broadcast receivers")
     }
 
     override fun onKeyEvent(event: KeyEvent): Boolean {
@@ -85,12 +99,15 @@ class HushAccessibilityService : AccessibilityService() {
     override fun onInterrupt() {
         Log.i(TAG, "Accessibility service interrupted")
         overlayManager.dismiss()
+        statusPillOverlay.dismiss()
     }
 
     override fun onDestroy() {
         overlayManager.dismiss()
+        statusPillOverlay.dismiss()
         unregisterReceiver(overlayReceiver)
         unregisterReceiver(injectReceiver)
+        unregisterReceiver(pillReceiver)
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/hush/app/StatusPillOverlay.kt
+++ b/app/src/main/java/com/hush/app/StatusPillOverlay.kt
@@ -1,0 +1,122 @@
+package com.hush.app
+
+import android.accessibilityservice.AccessibilityService
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.os.Handler
+import android.os.Looper
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.LinearLayout
+import android.widget.TextView
+
+class StatusPillOverlay(private val service: AccessibilityService) {
+
+    enum class PillType(val borderColor: Int) {
+        START(Color.parseColor("#6C63FF")),
+        DONE(Color.parseColor("#4ECDC4")),
+        ERROR(Color.parseColor("#FF6B6B"));
+
+        companion object {
+            fun fromString(value: String): PillType = when (value.uppercase()) {
+                "START" -> START
+                "DONE" -> DONE
+                "ERROR" -> ERROR
+                else -> START
+            }
+        }
+    }
+
+    companion object {
+        private const val AUTO_DISMISS_MS = 2500L
+        private const val BG_COLOR = "#F20D0D1A"
+        private const val TEXT_COLOR = "#E6FFFFFF"
+        private const val TEXT_SIZE_SP = 13f
+        private const val PADDING_H_DP = 12f
+        private const val PADDING_V_DP = 6f
+        private const val BORDER_WIDTH_DP = 2
+        private const val TOP_OFFSET_DP = 8f
+    }
+
+    private val windowManager = service.getSystemService(AccessibilityService.WINDOW_SERVICE) as WindowManager
+    private val handler = Handler(Looper.getMainLooper())
+    private val dismissRunnable = Runnable { dismiss() }
+    private var pillView: LinearLayout? = null
+
+    fun show(type: PillType, message: String) {
+        dismiss()
+
+        val dp = { value: Float ->
+            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, service.resources.displayMetrics).toInt()
+        }
+
+        val container = LinearLayout(service).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(PADDING_H_DP), dp(PADDING_V_DP), dp(PADDING_H_DP), dp(PADDING_V_DP))
+        }
+
+        val textView = TextView(service).apply {
+            text = message
+            setTextColor(Color.parseColor(TEXT_COLOR))
+            textSize = TEXT_SIZE_SP
+        }
+        container.addView(textView)
+
+        // Measure to get height for pill radius
+        container.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val pillHeight = container.measuredHeight.toFloat()
+
+        container.background = GradientDrawable().apply {
+            setColor(Color.parseColor(BG_COLOR))
+            setStroke(dp(BORDER_WIDTH_DP.toFloat()), type.borderColor)
+            cornerRadius = pillHeight / 2f
+        }
+
+        val statusBarHeight = getStatusBarHeight()
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+            y = statusBarHeight + dp(TOP_OFFSET_DP)
+        }
+
+        windowManager.addView(container, params)
+        pillView = container
+
+        handler.postDelayed(dismissRunnable, AUTO_DISMISS_MS)
+    }
+
+    fun show(typeString: String, message: String) {
+        show(PillType.fromString(typeString), message)
+    }
+
+    fun dismiss() {
+        handler.removeCallbacks(dismissRunnable)
+        pillView?.let {
+            try {
+                windowManager.removeView(it)
+            } catch (_: Exception) {
+                // View already removed
+            }
+        }
+        pillView = null
+    }
+
+    private fun getStatusBarHeight(): Int {
+        val resourceId = service.resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resourceId > 0) service.resources.getDimensionPixelSize(resourceId) else 0
+    }
+}

--- a/app/src/main/java/com/hush/app/StreamingOverlayManager.kt
+++ b/app/src/main/java/com/hush/app/StreamingOverlayManager.kt
@@ -70,7 +70,7 @@ class StreamingOverlayManager(private val service: AccessibilityService) {
             orientation = LinearLayout.VERTICAL
             setPadding(dp(12f), dp(8f), dp(12f), dp(8f))
             background = GradientDrawable().apply {
-                setColor(Color.parseColor("#F21A1A2E"))
+                setColor(Color.parseColor("#F20D0D1A"))
                 setStroke(1, Color.parseColor("#4D6C63FF"))
                 cornerRadius = dp(16f).toFloat()
             }

--- a/app/src/test/java/com/hush/app/StatusPillOverlayTest.kt
+++ b/app/src/test/java/com/hush/app/StatusPillOverlayTest.kt
@@ -1,0 +1,70 @@
+package com.hush.app
+
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StatusPillOverlayTest {
+
+    @Test
+    fun `START type has purple border color`() {
+        assertEquals(Color.parseColor("#6C63FF"), StatusPillOverlay.PillType.START.borderColor)
+    }
+
+    @Test
+    fun `DONE type has green border color`() {
+        assertEquals(Color.parseColor("#4ECDC4"), StatusPillOverlay.PillType.DONE.borderColor)
+    }
+
+    @Test
+    fun `ERROR type has red border color`() {
+        assertEquals(Color.parseColor("#FF6B6B"), StatusPillOverlay.PillType.ERROR.borderColor)
+    }
+
+    @Test
+    fun `fromString maps START correctly`() {
+        assertEquals(StatusPillOverlay.PillType.START, StatusPillOverlay.PillType.fromString("START"))
+    }
+
+    @Test
+    fun `fromString maps DONE correctly`() {
+        assertEquals(StatusPillOverlay.PillType.DONE, StatusPillOverlay.PillType.fromString("DONE"))
+    }
+
+    @Test
+    fun `fromString maps ERROR correctly`() {
+        assertEquals(StatusPillOverlay.PillType.ERROR, StatusPillOverlay.PillType.fromString("ERROR"))
+    }
+
+    @Test
+    fun `fromString is case insensitive`() {
+        assertEquals(StatusPillOverlay.PillType.START, StatusPillOverlay.PillType.fromString("start"))
+        assertEquals(StatusPillOverlay.PillType.DONE, StatusPillOverlay.PillType.fromString("done"))
+        assertEquals(StatusPillOverlay.PillType.ERROR, StatusPillOverlay.PillType.fromString("error"))
+    }
+
+    @Test
+    fun `fromString defaults to START for unknown values`() {
+        assertEquals(StatusPillOverlay.PillType.START, StatusPillOverlay.PillType.fromString("unknown"))
+    }
+
+    @Test
+    fun `ACTION_STATUS_PILL constant is correct`() {
+        assertEquals("com.hush.ACTION_STATUS_PILL", DictationService.ACTION_STATUS_PILL)
+    }
+
+    @Test
+    fun `EXTRA_PILL_TYPE constant is correct`() {
+        assertEquals("com.hush.EXTRA_PILL_TYPE", DictationService.EXTRA_PILL_TYPE)
+    }
+
+    @Test
+    fun `EXTRA_PILL_MESSAGE constant is correct`() {
+        assertEquals("com.hush.EXTRA_PILL_MESSAGE", DictationService.EXTRA_PILL_MESSAGE)
+    }
+
+    @Test
+    fun `EXTRA_WORD_COUNT constant is correct`() {
+        assertEquals("com.hush.EXTRA_WORD_COUNT", DictationService.EXTRA_WORD_COUNT)
+    }
+}


### PR DESCRIPTION
## Summary
- New **StatusPill overlay** at the top of the screen when dictating outside the app — compact pill with colored border that auto-dismisses after 2.5s
  - Purple: start (shows provider + version)
  - Green: done (word count or "no text field" / "no speech detected")
  - Red: error message
- **Streaming overlay** background reskinned from dark red (`#F21A1A2E`) to app dark (`#F20D0D1A`)
- `ACTION_INJECT_TEXT` now carries `EXTRA_WORD_COUNT` for the done pill

## Test plan
- [x] 221 unit tests pass (12 new StatusPillOverlayTest)
- [x] Emulator: START pill (purple) verified
- [x] Emulator: ERROR pill (red, "Invalid API key") verified
- [x] Pixel: all pill types verified by Leon

🤖 Generated with [Claude Code](https://claude.com/claude-code)